### PR TITLE
Extend card blur beyond stack edges

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -230,7 +230,7 @@ main.main-content {
 }
 
 .cards {
-  contain: layout paint;
+  contain: layout;
   display: grid;
   gap: 0.75rem;
   margin: 0 auto;
@@ -242,6 +242,11 @@ main.main-content {
   .cards {
     gap: 1rem;
   }
+}
+
+.cards[data-active="true"] {
+  padding-block: calc(var(--card-blur) * 1.5);
+  margin-block: calc(var(--card-blur) * -1.5);
 }
 
 .card {
@@ -369,6 +374,7 @@ main.main-content {
   position: fixed;
   inset: 0;
   z-index: 10;
+  pointer-events: none;
 }
 
   font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial, "Noto Sans", "Helvetica Neue", sans-serif;
@@ -564,7 +570,7 @@ main.main-content {
 }
 
 .cards {
-  contain: layout paint;
+  contain: layout;
   display: grid;
   gap: 0.75rem;
   margin: 0 auto;
@@ -576,6 +582,11 @@ main.main-content {
   .cards {
     gap: 1rem;
   }
+}
+
+.cards[data-active="true"] {
+  padding-block: calc(var(--card-blur) * 1.5);
+  margin-block: calc(var(--card-blur) * -1.5);
 }
 
 .cards[data-active="true"] .card:not(.expanded) {
@@ -698,4 +709,5 @@ main.main-content {
   position: fixed;
   inset: 0;
   z-index: 10;
+  pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- allow the cards grid to paint outside its box so blur can extend vertically past the stack
- add balanced negative margins/padding when a panel is expanded so the blur softens the top and bottom edges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb790e96c88321a2741325ba316450