### PR TITLE
Stabilize hero title alignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Header } from './components/Header'
 import { ITEMS } from './data/items'
@@ -55,10 +56,6 @@ export default function App(){
         sv: 'KONTAKT',
       },
     },
-    heroTitle: {
-      en: 'JPSSON / EXE',
-      sv: 'JPSSON / EXE',
-    },
     heroSubtitle: {
       en: 'Minimal UI <> No noise.',
       sv: 'Minimal UI <> No noise.',
@@ -109,13 +106,23 @@ export default function App(){
   }, [section])
 
   // Outside click close (but clicks on active card do not close)
-  const onRootClickCapture = (e: React.MouseEvent<HTMLDivElement>) => {
+  const onRootClickCapture = (e: ReactMouseEvent<HTMLDivElement>) => {
     if (!activeId || isLockedSection) return
     const node = cardRefs.current[activeId!]
     if (node && !node.contains(e.target as Node)) setActiveId(null)
   }
 
   const registerRef = (id: CardId, el: HTMLElement | null) => { cardRefs.current[id] = el }
+
+  const heroLabel = TEXT.header[section][language]
+
+  const heroLabelWidth = useMemo(() => {
+    const labels = Object.values(TEXT.header).flatMap(sectionLabels =>
+      Object.values(sectionLabels)
+    )
+
+    return labels.reduce((longest, current) => Math.max(longest, current.length), 0)
+  }, [])
 
   return (
     <div className="app-shell" onClickCapture={onRootClickCapture}>
@@ -133,7 +140,13 @@ export default function App(){
 
       <main className="container main-content">
         <section className="hero">
-          <h1>{TEXT.heroTitle[language]}</h1>
+          <h1
+            className="hero-title"
+            style={{ '--hero-label-width': `${heroLabelWidth}ch` } as CSSProperties}
+          >
+            <span className="hero-title__prefix">JPSSON&nbsp;/</span>
+            <span className="hero-title__label">{heroLabel}</span>
+          </h1>
           <p className="text-muted">{TEXT.heroSubtitle[language]}</p>
         </section>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Header } from './components/Header'
@@ -66,6 +66,17 @@ export default function App(){
     },
   }
 
+  const heroLabelRef = useRef<HTMLSpanElement | null>(null)
+  const [heroLabelWidth, setHeroLabelWidth] = useState<number | null>(null)
+
+  const heroLabels = useMemo(
+    () =>
+      Object.values(TEXT.header).flatMap(sectionLabels =>
+        Object.values(sectionLabels)
+      ),
+    []
+  )
+
   // map of card refs to detect outside clicks without an overlay
   const cardRefs = useRef<Record<CardId, HTMLElement | null>>({
     tool: null, exchange: null, boardgame: null, pos: null, about: null, contact: null,
@@ -116,13 +127,39 @@ export default function App(){
 
   const heroLabel = TEXT.header[section][language]
 
-  const heroLabelWidth = useMemo(() => {
-    const labels = Object.values(TEXT.header).flatMap(sectionLabels =>
-      Object.values(sectionLabels)
-    )
+  useLayoutEffect(() => {
+    if (typeof window === 'undefined') return
+    const node = heroLabelRef.current
+    if (!node || heroLabels.length === 0) return
 
-    return labels.reduce((longest, current) => Math.max(longest, current.length), 0)
-  }, [])
+    const computedStyle = window.getComputedStyle(node)
+    const measureNode = document.createElement('span')
+    measureNode.style.position = 'absolute'
+    measureNode.style.visibility = 'hidden'
+    measureNode.style.whiteSpace = 'nowrap'
+    measureNode.style.pointerEvents = 'none'
+    measureNode.style.fontFamily = computedStyle.fontFamily
+    measureNode.style.fontSize = computedStyle.fontSize
+    measureNode.style.fontWeight = computedStyle.fontWeight
+    measureNode.style.letterSpacing = computedStyle.letterSpacing
+    measureNode.style.fontStyle = computedStyle.fontStyle
+    measureNode.style.textTransform = computedStyle.textTransform
+
+    document.body.appendChild(measureNode)
+
+    let maxWidth = 0
+    for (const label of heroLabels) {
+      measureNode.textContent = label
+      const { width } = measureNode.getBoundingClientRect()
+      if (width > maxWidth) {
+        maxWidth = width
+      }
+    }
+
+    document.body.removeChild(measureNode)
+
+    setHeroLabelWidth(maxWidth)
+  }, [heroLabels])
 
   return (
     <div className="app-shell" onClickCapture={onRootClickCapture}>
@@ -142,10 +179,13 @@ export default function App(){
         <section className="hero">
           <h1
             className="hero-title"
-            style={{ '--hero-label-width': `${heroLabelWidth}ch` } as CSSProperties}
+            style={{
+              '--hero-label-width':
+                heroLabelWidth != null ? `${heroLabelWidth}px` : undefined,
+            } as CSSProperties}
           >
             <span className="hero-title__prefix">JPSSON&nbsp;/</span>
-            <span className="hero-title__label">{heroLabel}</span>
+            <span ref={heroLabelRef} className="hero-title__label">{heroLabel}</span>
           </h1>
           <p className="text-muted">{TEXT.heroSubtitle[language]}</p>
         </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -255,6 +255,22 @@ main.main-content {
   font-size: clamp(1.875rem, 4vw, 2.25rem);
 }
 
+.hero-title {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5ch;
+}
+
+.hero-title__prefix {
+  white-space: nowrap;
+}
+
+.hero-title__label {
+  display: inline-block;
+  min-width: var(--hero-label-width, 0ch);
+  text-align: left;
+}
+
 .hero p {
   margin-top: 0.75rem;
   font-size: 0.875rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -267,7 +267,8 @@ main.main-content {
 
 .hero-title__label {
   display: inline-block;
-  min-width: var(--hero-label-width, 0ch);
+  width: var(--hero-label-width, auto);
+  min-width: var(--hero-label-width, auto);
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- split the hero heading into separate prefix and label spans
- compute the longest section label width and apply it so the prefix stays fixed while the label swaps
- add styling for the hero title to keep the alignment consistent across languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb9b4e55d083219dd1b0c4b933e598